### PR TITLE
Removed history state assignation

### DIFF
--- a/src/routes-router.js
+++ b/src/routes-router.js
@@ -233,9 +233,9 @@ export class RouterElement extends HTMLElement {
     oldRoute._lastChangedAt = now;
 
     if (shouldReplace) {
-      window.history.replaceState(history.state, '', fullNewUrl);
+      window.history.replaceState(window.history.state, '', fullNewUrl);
     } else {
-      window.history.pushState(history.state, '', fullNewUrl);
+      window.history.pushState(window.history.state, '', fullNewUrl);
     }
   }
 

--- a/src/routes-router.js
+++ b/src/routes-router.js
@@ -233,9 +233,9 @@ export class RouterElement extends HTMLElement {
     oldRoute._lastChangedAt = now;
 
     if (shouldReplace) {
-      window.history.replaceState({}, '', fullNewUrl);
+      window.history.replaceState(history.state, '', fullNewUrl);
     } else {
-      window.history.pushState({}, '', fullNewUrl);
+      window.history.pushState(history.state, '', fullNewUrl);
     }
   }
 


### PR DESCRIPTION
Simply removed the history state assignation.

This allows us to easily share serializable objects between routes by replacing the history state during regular code flow or in the onRouteLeave guard.